### PR TITLE
Add ContentOnly option for directory transfers

### DIFF
--- a/transfer.go
+++ b/transfer.go
@@ -179,6 +179,10 @@ type DirTransferOption struct {
 	// Default: 0 (Means no limit)
 	// TODO: not implemented yet
 	SpeedLimit int64
+	// ContentOnly skips creating the source directory on the receiving side, and
+	// only transfers the source directory's contents.
+	// Default: false
+	ContentOnly bool
 }
 
 // CopyDirToRemote recursively copies a directory to remoteDir.
@@ -268,7 +272,9 @@ func traverseDir(ctx context.Context, rootDir bool, dir *os.File, opt *DirTransf
 		return
 	}
 
-	deliverDir(ctx, curDirStat, opt, jobCh)
+	if !(rootDir && opt.ContentOnly) {
+		deliverDir(ctx, curDirStat, opt, jobCh)
+	}
 
 	var subDirs []os.FileInfo
 	for i := range list {


### PR DESCRIPTION
Normally, copying a directory also creates a directory with the same name on the target side of the transfer. For example:

    $ scp -r source remote:/some/path
    source/file1           > remote:/some/path/source/file1
    source/folder1/file2   > remote:/some/path/source/folder1/file2

If we don't want to create a new directory on the target side we can use a glob after the source, indicating an scp operation for each file or folder inside:

    $ scp -r source/* remote:/some/path
    source/file1           > remote:/some/path/file1
    source/folder1/file2   > remote:/some/path/folder1/file2

When ContentOnly is true, creation of the source directory on the target side is skipped and the contents are copied into the existing directory instead, using a single connection and job queue.